### PR TITLE
Uncomment sub AUTOLOAD in release 20181025

### DIFF
--- a/constant.cpp
+++ b/constant.cpp
@@ -72,6 +72,8 @@ static ConstantStruct gsConst[] =
 
 #ifdef SERVICE_CONTROL_PRESHUTDOWN
 	{ TEXT( "SERVICE_CONTROL_PRESHUTDOWN"),		(LPVOID) (SERVICE_CONTROL_PRESHUTDOWN),		Numeric },
+#else
+	{ TEXT( "SERVICE_CONTROL_PRESHUTDOWN"),		(LPVOID) NULL,					NotPresent },
 #endif
 
     //  Service bits available to a script
@@ -102,14 +104,20 @@ static ConstantStruct gsConst[] =
     
 #ifdef SERVICE_ACCEPT_HARDWAREPROFILECHANGE
     { TEXT( "SERVICE_ACCEPT_HARDWAREPROFILECHANGE" ), (LPVOID) (SERVICE_ACCEPT_HARDWAREPROFILECHANGE),    Numeric },   
+#else
+    { TEXT( "SERVICE_ACCEPT_HARDWAREPROFILECHANGE" ), (LPVOID) NULL,                                      NotPresent },
 #endif // SERVICE_ACCEPT_HARDWAREPROFILECHANGE
 
 #ifdef SERVICE_ACCEPT_POWEREVENT
     { TEXT( "SERVICE_ACCEPT_POWEREVENT" ),      (LPVOID) (SERVICE_ACCEPT_POWEREVENT),    Numeric },   
+#else
+    { TEXT( "SERVICE_ACCEPT_POWEREVENT" ),      (LPVOID) NULL,                           NotPresent },
 #endif // SERVICE_ACCEPT_POWEREVENT
 
 #ifdef SERVICE_ACCEPT_SESSIONCHANGE
     { TEXT( "SERVICE_ACCEPT_SESSIONCHANGE" ),   (LPVOID) (SERVICE_ACCEPT_SESSIONCHANGE),    Numeric },   
+#else
+    { TEXT( "SERVICE_ACCEPT_SESSIONCHANGE" ),   (LPVOID) NULL,                              NotPresent },
 #endif // SERVICE_ACCEPT_SESSIONCHANGE
     
     

--- a/lib/Win32/Daemon.pm
+++ b/lib/Win32/Daemon.pm
@@ -7,6 +7,7 @@ our $XS_VERSION = $VERSION;
 use strict;
 use warnings;
 use Carp;
+use AutoLoader;
 use Exporter qw(import);
 require XSLoader;
 

--- a/lib/Win32/Daemon.pm
+++ b/lib/Win32/Daemon.pm
@@ -6,6 +6,7 @@ our $XS_VERSION = $VERSION;
 
 use strict;
 use warnings;
+use Carp;
 use Exporter qw(import);
 require XSLoader;
 
@@ -121,7 +122,7 @@ sub AUTOLOAD
         # that is, the extension knows that the constant exists but for
         # some wild reason it was not compiled with it.
         my ($package,$file,$line) = caller;
-        print "Your vendor has not defined 'Win32::Daemon' macro $Constant, used in $file at line $line.";
+        croak "Your vendor has not defined 'Win32::Daemon' macro $Constant, used in $file at line $line.";
     }
     elsif( 2 == $Result )
     {

--- a/lib/Win32/Daemon.pm
+++ b/lib/Win32/Daemon.pm
@@ -95,44 +95,44 @@ our @EXPORT = qw(
 
 our @EXPORT_OK = qw();
 
-# sub AUTOLOAD
-# {
-#     # This AUTOLOAD is used to 'autoload' constants from the constant()
-#     # XS function.  If a constant is not found then control is passed
-#     # to the AUTOLOAD in AutoLoader.
-#
-#     my( $Constant ) = $AUTOLOAD;
-#     my( $Result, $Value );
-#     $Constant =~ s/.*:://;
-#
-#     $Result = Constant( $Constant, $Value );
-#
-#     if( 0 == $Result )
-#     {
-#         # The extension could not resolve the constant...
-#         $AutoLoader::AUTOLOAD = $AUTOLOAD;
-#             goto &AutoLoader::AUTOLOAD;
-#         return;
-#     }
-#     elsif( 1 == $Result )
-#     {
-#         # $Result == 1 if the constant is valid but not defined
-#         # that is, the extension knows that the constant exists but for
-#         # some wild reason it was not compiled with it.
-#         $pack = 0;
-#         ($pack,$file,$line) = caller;
-#         print "Your vendor has not defined 'Win32::Daemon' macro $constname, used in $file at line $line.";
-#     }
-#     elsif( 2 == $Result )
-#     {
-#         # If $Result == 2 then we have a string value
-#         $Value = "'$Value'";
-#     }
-#         # If $Result == 3 then we have a numeric value
-#
-#     eval "sub $AUTOLOAD { return( $Value ); }";
-#     goto &$AUTOLOAD;
-# }
+sub AUTOLOAD
+{
+    # This AUTOLOAD is used to 'autoload' constants from the constant()
+    # XS function.  If a constant is not found then control is passed
+    # to the AUTOLOAD in AutoLoader.
+
+    our $AUTOLOAD;
+    my( $Constant ) = $AUTOLOAD;
+    my( $Result, $Value );
+    $Constant =~ s/.*:://;
+
+    $Result = Constant( $Constant, $Value );
+
+    if( 0 == $Result )
+    {
+        # The extension could not resolve the constant...
+        $AutoLoader::AUTOLOAD = $AUTOLOAD;
+            goto &AutoLoader::AUTOLOAD;
+        return;
+    }
+    elsif( 1 == $Result )
+    {
+        # $Result == 1 if the constant is valid but not defined
+        # that is, the extension knows that the constant exists but for
+        # some wild reason it was not compiled with it.
+        my ($package,$file,$line) = caller;
+        print "Your vendor has not defined 'Win32::Daemon' macro $Constant, used in $file at line $line.";
+    }
+    elsif( 2 == $Result )
+    {
+        # If $Result == 2 then we have a string value
+        $Value = "'$Value'";
+    }
+        # If $Result == 3 then we have a numeric value
+
+    eval "sub $AUTOLOAD { return( $Value ); }";
+    goto &$AUTOLOAD;
+}
 
 
 # For a module, you *always* return TRUE...

--- a/t/10-export.t
+++ b/t/10-export.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use Win32::Daemon;
+
+# Needs an update when Win32::Daemon::EXPORT count changes
+plan tests => 63;
+
+my %vals;
+foreach my $to_export (@Win32::Daemon::EXPORT)
+{
+	like(eval("Win32::Daemon::$to_export; 'ok'") || $@,
+		 qr/^(ok|Your vendor has not defined 'Win32::Daemon' macro.*)$/,
+		 "$to_export");
+
+	$vals{$to_export} = eval("Win32::Daemon::$to_export;") || $@;
+}
+
+# Uncomment these to see the list of values and possible exceptions
+#use Data::Dumper;
+#$Data::Dumper::Sortkeys = 1;
+#print Dumper(\%vals);


### PR DESCRIPTION
Constants, such as SERVICE_ACCEPT_STOP, were no longer working with
Win32-Daemon-20181025.

Uncommenting sub AUTOLOAD in lib/Win32/Daemon.pm, and adjusting it to run with
strict and warnings enabled, seems to fix this.
