### PR TITLE
Add support for dwMajorVersion greater than 6 in DllMain()

### DIFF
--- a/Daemon.xs
+++ b/Daemon.xs
@@ -958,12 +958,7 @@ BOOL WINAPI DllMain( HINSTANCE  hinstDLL, DWORD fdwReason, LPVOID  lpvReserved )
 			gdwControlsAccepted = 0;
 			switch( gsOSVerInfo.dwMajorVersion )
 			{
-				case 11 ... 1000000:  // assume version will never reach a million
-				case 10:
-				case 9:
-				case 8:
-				case 7:
-				case 6:
+				default:
 					// We have Windows Vista
 					//  The following constants only work on Vista and higher:
 					//      SERVICE_ACCEPT_PRESHUTDOWN

--- a/Daemon.xs
+++ b/Daemon.xs
@@ -958,6 +958,11 @@ BOOL WINAPI DllMain( HINSTANCE  hinstDLL, DWORD fdwReason, LPVOID  lpvReserved )
 			gdwControlsAccepted = 0;
 			switch( gsOSVerInfo.dwMajorVersion )
 			{
+				case 11 ... 1000000:  // assume version will never reach a million
+				case 10:
+				case 9:
+				case 8:
+				case 7:
 				case 6:
 					// We have Windows Vista
 					//  The following constants only work on Vista and higher:


### PR DESCRIPTION
A bug in `DllMain()` makes the `switch` statement only work for `dwMajorVersion` up to version 6. The effect is that `gdwControlsAccepted` (which is later passed to `SetServiceStatus()`) is set to zero (the default value) if `dwMajorVersion` is  greater than 6, which again causes the `SERVICE_ACCEPT_STOP`, `SERVICE_ACCEPT_PAUSE_CONTINUE`, and `SERVICE_ACCEPT_SHUTDOWN` bits to not be set. The end result is that once a service has been created and started it is impossible to stop, pause and shutdown a service from the "Services" app in Windows 7, 8, 9, 10, ... (tested on Windows 10) . Also the `net stop` command also refuses to stop the service.